### PR TITLE
use a data-lang attribute to allow takeovers to belong to any languag…

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -137,8 +137,13 @@
         var languageClass = browserLanguage || 'en';
         languageClass = languageClass.split('-')[0];
 
-        // set the default takeovers to english
-        var defaultTakeovers = document.querySelectorAll('.js-takeover[data-lang="en"]');
+        // set the default takeover or if use the first one
+        var defaultTakeovers = document.querySelectorAll(
+          '.js-takeover[data-default="true"]'
+        );
+        if (!defaultTakeovers) {
+          defaultTakeovers = takeovers[0];
+        }
 
         // find any takeovers that match the users language
         var query = '.js-takeover[data-lang*="'+languageClass+'"]';

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -112,32 +112,39 @@
       {# include "ubuntu/takeovers/_footer_homepage.html" #}
     {% endblock footer_content %}
     <script>
-        var detectLanguage = function () {
-            var lang = window.navigator.languages ? window.navigator.languages[0] : null; 
-            lang = lang || window.navigator.language ||
-            window.navigator.browserLanguage || window.navigator.userLanguage;
+      // detect the user's browser's language setting
+      var detectLanguage = function () {
+        var lang = window.navigator.languages ? window.navigator.languages[0] : null;
+        lang = lang || window.navigator.language ||
+        window.navigator.browserLanguage || window.navigator.userLanguage;
 
-            if (lang && lang.length) {
-                return lang;
-            } else {
-                return null
-            }
-        };
+        if (lang && lang.length) {
+          return lang;
+        } else {
+          return null
+        }
+      };
     </script>
     <script>
       if (window.localStorage && window.sessionStorage) {
         var takeovers = document.getElementsByClassName('js-takeover');
         for (t = 0; t < takeovers.length; ++t) {
+            // hide all takeovers
             takeovers[t].classList.add('u-hide');
         }
+        // get the users language and remove any extra detail suffix (e.g. -gb)
         var browserLanguage = detectLanguage();
         var languageClass = browserLanguage || 'en';
         languageClass = languageClass.split('-')[0];
-        var defaultTakeovers = document.querySelectorAll('.js-takeover[lang="en"]');
-        var query = '.js-takeover[lang="'+languageClass+'"]';
+
+        // set the default takeovers to english
+        var defaultTakeovers = document.querySelectorAll('.js-takeover[data-lang="en"]');
+
+        // find any takeovers that match the users language
+        var query = '.js-takeover[data-lang*="'+languageClass+'"]';
         var takeoversFiltered = (document.querySelectorAll(query));
         takeoversFiltered = (takeoversFiltered.length) ? takeoversFiltered : defaultTakeovers;
-         
+
         if (!localStorage.getItem('TAKEOVER')) {
           var i = Math.floor(Math.random() * takeoversFiltered.length);
           localStorage.setItem('TAKEOVER', i);

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,9 +3,27 @@
 {% block head_extra %}
 {% endblock %}
 
-{% block takeover_content %} 
-    {% include "takeovers/_robotics-takeover.html" with nojs_fallback=True %} 
-    {% include "takeovers/_multicloud-operations.html" %} 
+{#
+  TAKEOVER INSTRUCTIONS
+
+  - A takeover can belong to more than one language group and therefore
+    you can build a queue of them to rotate based on the user's language
+    settings. For example data-lang="de" will be for german only, while
+    data-lang="en,de" will be for english and german.
+  - Additionally, you should add a lang="en-gb" or lang="de" for the
+    takeovers to allow for automatic translation
+
+    EXAMPLE SECTION TAG
+
+      section lang="en" data-lang="en" class="p-strip is-deep p-takeover--robotics js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}
+
+  - Also, add a 'with default=True' below for one takeover to be the default
+  
+  #}
+
+{% block takeover_content %}
+    {% include "takeovers/_robotics-takeover.html" with default=True %}
+    {% include "takeovers/_multicloud-operations.html" %}
     {% include "takeovers/_financial-services.html" %}
-    {% include "takeovers/_de-vmware-to-os.html" with nojs_fallback=True %}
+    {% include "takeovers/_de-vmware-to-os.html" %}
 {% endblock takeover_content %}

--- a/templates/takeovers/_ai_webinar-2018-10-01.html
+++ b/templates/takeovers/_ai_webinar-2018-10-01.html
@@ -1,10 +1,10 @@
-<section class="p-strip is-deep p-takeover--ai-webinar js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
+<section data-lang="en" lang="en-gb" class="p-strip is-deep p-takeover--ai-webinar js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
-      <h1 class="p-takeover__title">Artificial intelligence, machine learning and Ubuntu</h1>
-      <p class="p-takeover__text">Find out how you can use Ubuntu to power your AI and ML ambitions from developer workstations to the cloud.</p>
+      <h1 class="p-takeover__title">How to build and deploy your first AI/ML model on Ubuntu</h1>
+      <p class="p-takeover__text">We will walk you through running a Kaggle experiment using Kubeflow on Microk8s.</p>
       <div class="u-hide--small">
-        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" class="p-button--positive u-no-margin--bottom">Watch on-demand</a>
+        <a href="https://www.brighttalk.com/webcast/6793/336267" class="p-button--positive u-no-margin--bottom">Register for the webinar</a>
       </div>
     </div>
     <div class="col-6 u-align--center u-vertically-center">
@@ -17,7 +17,7 @@
         <img class="server-picto" src="{{ ASSET_SERVER_URL }}fd20f946-server-icon.svg" alt="">
       </div>
       <div class="u-hide--medium u-hide--large">
-        <a href="/engage/ai-ml-ubuntu?utm_source=takeover&utm_campaign=FY19_Cloud_K8_WBN_AIML" class="p-button--positive u-no-margin--bottom">Watch on-demand</a>
+        <a href="https://www.brighttalk.com/webcast/6793/336267" class="p-button--positive u-no-margin--bottom">Watch on-demand</a>
       </div>
     </div>
   </div>

--- a/templates/takeovers/_de-vmware-to-os.html
+++ b/templates/takeovers/_de-vmware-to-os.html
@@ -1,4 +1,4 @@
-<section lang="de" class="p-strip is-deep p-takeover--vmware-to-os js-takeover {% if not nojs_fallback %}u-hide{% endif %} lang-de">
+<section lang="de" data-lang="de" class="p-strip is-deep p-takeover--vmware-to-os js-takeover {% if not nojs_fallback %}u-hide{% endif %} lang-de">
   <div class="row u-equal-height">
     <div class="col-7">
       <h1 class="p-takeover__title">Von VMware zu Canonical OpenStack</h1>

--- a/templates/takeovers/_de-vmware-to-os.html
+++ b/templates/takeovers/_de-vmware-to-os.html
@@ -1,4 +1,4 @@
-<section lang="de" data-lang="de" class="p-strip is-deep p-takeover--vmware-to-os js-takeover {% if not nojs_fallback %}u-hide{% endif %} lang-de">
+<section lang="de" data-lang="de" class="p-strip is-deep p-takeover--vmware-to-os js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-7">
       <h1 class="p-takeover__title">Von VMware zu Canonical OpenStack</h1>

--- a/templates/takeovers/_financial-services.html
+++ b/templates/takeovers/_financial-services.html
@@ -1,4 +1,4 @@
-<section lang="en" class="p-strip is-deep p-takeover--financial-services js-takeover {% if not nojs_fallback %}u-hide{% endif %} lang-de lang-all">
+<section lang="en" data-lang="en,de" class="p-strip is-deep p-takeover--financial-services js-takeover {% if not nojs_fallback %}u-hide{% endif %} lang-de lang-all">
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Financial Services Month</h1>

--- a/templates/takeovers/_financial-services.html
+++ b/templates/takeovers/_financial-services.html
@@ -1,4 +1,4 @@
-<section lang="en" data-lang="en,de" class="p-strip is-deep p-takeover--financial-services js-takeover {% if not nojs_fallback %}u-hide{% endif %} lang-de lang-all">
+<section lang="en" data-lang="en,de" class="p-strip is-deep p-takeover--financial-services js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Financial Services Month</h1>

--- a/templates/takeovers/_multicloud-operations.html
+++ b/templates/takeovers/_multicloud-operations.html
@@ -1,4 +1,4 @@
-<section  lang="en" class="p-strip--image is-deep js-takeover is-bordered p-takeover--multicloud-operations {% if not nojs_fallback %}u-hide{% endif %} lang-all">
+<section  lang="en" data-lang="en" class="p-strip--image is-deep js-takeover is-bordered p-takeover--multicloud-operations {% if not nojs_fallback %}u-hide{% endif %} lang-all">
   <div class="row u-vertically-center">
     <div class="col-7" itemscope="" itemtype="https://schema.org/Event">
       <p class="p-muted-heading" style="font-size: 1rem;">CIO Guide to multi-cloud operations</p>

--- a/templates/takeovers/_multicloud-operations.html
+++ b/templates/takeovers/_multicloud-operations.html
@@ -1,4 +1,4 @@
-<section  lang="en" data-lang="en" class="p-strip--image is-deep js-takeover is-bordered p-takeover--multicloud-operations {% if not nojs_fallback %}u-hide{% endif %} lang-all">
+<section  lang="en" data-lang="en" class="p-strip--image is-deep js-takeover is-bordered p-takeover--multicloud-operations {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-vertically-center">
     <div class="col-7" itemscope="" itemtype="https://schema.org/Event">
       <p class="p-muted-heading" style="font-size: 1rem;">CIO Guide to multi-cloud operations</p>

--- a/templates/takeovers/_rigado_webinar.html
+++ b/templates/takeovers/_rigado_webinar.html
@@ -1,4 +1,4 @@
-<section class="p-strip is-deep p-takeover--rigado-webinar js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
+<section class="p-strip is-deep p-takeover--rigado-webinar js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-8 u-fade-left--medium">
       <h1 class="p-takeover__title">Managing IoT security at scale</h1>

--- a/templates/takeovers/_robotics-takeover.html
+++ b/templates/takeovers/_robotics-takeover.html
@@ -1,4 +1,4 @@
-<section lang="en" class="p-strip is-deep p-takeover--robotics js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
+<section lang="en" data-lang="en" class="p-strip is-deep p-takeover--robotics js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Selecting the optimum OS for your robot</h1>

--- a/templates/takeovers/_robotics-takeover.html
+++ b/templates/takeovers/_robotics-takeover.html
@@ -1,4 +1,4 @@
-<section lang="en" data-lang="en" class="p-strip is-deep p-takeover--robotics js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
+<section lang="en" data-lang="en" class="p-strip is-deep p-takeover--robotics js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-6">
       <h1 class="p-takeover__title">Selecting the optimum OS for your robot</h1>

--- a/templates/takeovers/_tackling_iot.html
+++ b/templates/takeovers/_tackling_iot.html
@@ -1,4 +1,4 @@
-<section class="p-strip p-takeover is-deep js-takeover {% if not nojs_fallback %}u-hide{% endif %}">
+<section class="p-strip p-takeover is-deep js-takeover {% if not default %}u-hide{% endif %}" {% if default %}data-default="true"{% endif %}>
   <div class="row u-equal-height">
     <div class="col-8 suffix-2">
       <h1 class="p-takeover__title">Tackling the I<span class="u-adjust-kerning">oT</span> monetisation challenge</h1>


### PR DESCRIPTION
## Done

- extend Shehu's PR to use a **data-lang** attribute to allow takeovers to belong to any language group and queue
  - a takeover can belong to more than one language group and therefore you can build a queue of them to rotate based on the user's language settings
  - example ```data-lang="de"``` will be for german only, while  ```data-lang="en,de"``` will be for english and german

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- go to chrome://settings/languages (or the firefox equiv) and change your language between english and german and reload the homepage.


